### PR TITLE
Add softPurgeKey method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -82,7 +82,7 @@ Fastly.prototype.request = function (method, url, params, headers) {
     debug('Request: ' + method + ', ' + url);
 
     // Construct headers
-    headers = Object.assign({}, { 'x-fastly-key': self.apikey }, headers || {});
+    headers = Object.assign({ 'x-fastly-key': self.apikey }, headers || {});
 
     // HTTP request
     request({
@@ -132,7 +132,7 @@ Fastly.prototype.purgeKey = function (service, key) {
 };
 
 Fastly.prototype.softPurgeKey = function (service, key) {
-    var url = '/service/' + encodeURIComponent(service) + '/purge/' + key;
+    var url = '/service/' + encodeURIComponent(service) + '/purge/' + encodeURIComponent(key);
     return this.request('POST', url, null, { 'fastly-soft-purge': 1 });
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,10 +65,11 @@ function Fastly (apikey, service, options) {
  * @param {string} Method
  * @param {string} URL
  * @param {params} Optional params to update.
+ * @param {Object} Headers
  *
  * @return {Object}
  */
-Fastly.prototype.request = function (method, url, params) {
+Fastly.prototype.request = function (method, url, params, headers) {
 
     var deferred = Q.defer();
     var self = this;
@@ -81,7 +82,7 @@ Fastly.prototype.request = function (method, url, params) {
     debug('Request: ' + method + ', ' + url);
 
     // Construct headers
-    var headers = { 'x-fastly-key': self.apikey };
+    headers = Object.assign({}, { 'x-fastly-key': self.apikey }, headers || {});
 
     // HTTP request
     request({
@@ -128,6 +129,11 @@ Fastly.prototype.purgeAll = function (service) {
 Fastly.prototype.purgeKey = function (service, key) {
     var url = '/service/' + encodeURIComponent(service) + '/purge/' + key;
     return this.request('POST', url);
+};
+
+Fastly.prototype.softPurgeKey = function (service, key) {
+    var url = '/service/' + encodeURIComponent(service) + '/purge/' + key;
+    return this.request('POST', url, null, { 'fastly-soft-purge': 1 });
 };
 
 Fastly.prototype.stats = function (service) {

--- a/test/unit/interface.js
+++ b/test/unit/interface.js
@@ -9,6 +9,7 @@ test('unit', function (t) {
 
     t.type(ready, 'object', 'module exposes an object');
     t.type(ready.request, 'function', 'request method exists');
+    t.type(ready.softPurgeKey, 'function', 'softPurgeKey method exists');
 
     methods.forEach(m => {
         t.type(ready[m], 'function', `${m} method exists`);


### PR DESCRIPTION
Hi

I added [soft purge](https://docs.fastly.com/api/purge#soft_purge_2e4d29085640127739f8467f27a5b549) method to this library. Original repo have already supported soft-purge, but I want to use ft forked one because this API returns promise, has a feature to manipulate VCL, etc.